### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/MessagePack.pm6
+++ b/lib/MessagePack.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module MessagePack;
+unit module MessagePack;
 
 use MessagePack::Unpacker;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.